### PR TITLE
Add SecObserve to the list of CSAF tools

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -21,6 +21,7 @@
 - CSAF Content Management System
 - CSAF Downloader
 - CSAF Walker
+- SecObserve
 - Trivy ">
 
   <title>CSAF Open Source Tools</title>
@@ -210,6 +211,15 @@
                         <div class="card-box">
                             <h4 class="card-title mbr-fonts-style display-5"><a href="https://github.com/ctron/csaf-walker" class="text-primary" target="_blank">CSAF Walker</a></h4>
                             <p class="card-text mbr-fonts-style display-4">A Rust library and command line tool for consuming and analyzing CSAF documents.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-wrapper">
+
+                        <div class="card-box">
+                            <h4 class="card-title mbr-fonts-style display-5"><a href="https://github.com/MaibornWolff/SecObserve" class="text-primary" target="_blank">SecObserve</a></h4>
+                            <p class="card-text mbr-fonts-style display-4">An open source vulnerability management system that can generate CSAF VEX documents.</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The open source vulnerability management system [SecObserve](https://github.com/MaibornWolff/SecObserve) can generate CSAF VEX documents based on assessments. Consumption of CSAF VEX documents is planned for the future. 

It would be great if it would be mentioned on the CSAF tools page.