### PR TITLE
Add `Clouditor` to tools

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -21,6 +21,7 @@
 - CSAF Content Management System
 - CSAF Downloader
 - CSAF Walker
+- Clouditor
 - SecObserve
 - Trivy ">
 
@@ -211,6 +212,15 @@
                         <div class="card-box">
                             <h4 class="card-title mbr-fonts-style display-5"><a href="https://github.com/ctron/csaf-walker" class="text-primary" target="_blank">CSAF Walker</a></h4>
                             <p class="card-text mbr-fonts-style display-4">A Rust library and command line tool for consuming and analyzing CSAF documents.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-wrapper">
+
+                        <div class="card-box">
+                            <h4 class="card-title mbr-fonts-style display-5"><a href="https://github.com/clouditor/clouditor?tab=readme-ov-file#using-the-extra-discoverers-eg-csaf" class="text-primary" target="_blank">Clouditor</a></h4>
+                            <p class="card-text mbr-fonts-style display-4">Clouditor is a tool for the continuous assurance of cloud and other backend services. It supports the conformance check of CSAF (trusted) providers as part of vulnerability management controls.</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
We have recently introduced support for the conformance check of CSAF (trusted) providers into our clouditor compliance platform. See https://github.com/clouditor/clouditor/issues/1414 for more information. We have also provided a small quick start in our README how to do it in https://github.com/clouditor/clouditor?tab=readme-ov-file#quickstart-with-ui.

There are some limitations, e.g. currently all available documents are scanned for integrity/TLS, etc. This might take too much time for large providers. We are aware of this issue (see https://github.com/clouditor/clouditor/issues/1453, https://github.com/clouditor/clouditor/issues/1454)
