### PR TITLE
remove CNAME as minor cleanup

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -52,7 +52,7 @@ jobs:
         env:
           HUGO_ENVIRONMENT: production
           TZ: Europe/Berlin
-        run: hugo --gc --minify --baseURL "https://www.csaf.dev"
+        run: hugo --gc --minify --baseURL "https://csaf.io"
 
       - name: Remove .license files from 'public' folder
         run: find public -type f -name "*.license" -exec rm -f {} \;

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.csaf.io

--- a/content/community-days/2025.md
+++ b/content/community-days/2025.md
@@ -3,7 +3,7 @@ title: 'Community Days 2025'
 subtitle: 'Call for Presentations'
 weight: 2
 type: 'event'
-draft: true
+draft: false
 
 params:
   event:


### PR DESCRIPTION

  .. as we are using a custom "GitHub Actions workflow", the following
  holds:
     https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors

> If you are publishing from a custom GitHub Actions workflow, any CNAME file is ignored and is not required.

  A file that is unused should be deleted to not irritate other developers and contributors.