### PR TITLE
Add upcoming specification, restyle legacy

### DIFF
--- a/assets/scss/custom/blocks/_buttons.scss
+++ b/assets/scss/custom/blocks/_buttons.scss
@@ -18,6 +18,18 @@
   }
 }
 
+.btn-outline-muted {
+  &:hover,
+  &:active,
+  &:focus,
+  &:focus-visible,
+  &:target {
+    background-color: lighten($muted, 53%) !important;
+    color: $muted !important;
+    background: none;
+  }
+}
+
 .btn-sm-100 {
   @include media-breakpoint-down(md) {
     display: block;

--- a/assets/scss/custom/pages/_specifications.scss
+++ b/assets/scss/custom/pages/_specifications.scss
@@ -34,6 +34,10 @@
 
     .btn {
       font-weight: 550;
+
+      &-outline-muted {
+        border-color: lighten($muted, 35%) !important;
+      }
     }
   }
 

--- a/layouts/_default/specification.html
+++ b/layouts/_default/specification.html
@@ -15,10 +15,16 @@
          class="btn btn-primary">
         CSAF 2.0 Standard
       </a>
+      <a
+        href="https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html"
+        class="btn btn-outline-primary"
+      >
+        CSAF 2.1 (Upcoming)
+      </a>
       <a href="https://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/csaf-cvrf-v1.2.html"
 
-         class="btn btn-outline-primary">
-        CVRF 1.2 (legacy)
+         class="btn btn-outline-muted">
+        CVRF 1.2 (Legacy)
       </a>
     </div>
     <!-- #endregion -->


### PR DESCRIPTION
Closes #102 and https://github.com/csaf-auxiliary/csaf-documentation-staging/issues/1#issuecomment-3187318480

- Inserted link to the upcoming version between current and legacy;
- Made legacy button more gray;
- Styled button for upcoming specification the way 1.2 was styled before.

**Result:** 1.2 and 2.0 are visually completely different, while 2.1 has similarities with both of them:
- The shade of blue is the same as for 2.0 and much more intence as 1.2 => These 2 buttons pull more attention than 1.2;
- Background is white initially and gray on hover => It is visually different from the current specification and has less visual weight.

Is the used link correct: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html?