### PR TITLE
Add redirecting to FAQ

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -1,0 +1,9 @@
+---
+type: redirect
+target: https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/guidance/faq.md
+---
+
+<!--
+  SPDX-FileCopyrightText: 2025 OASIS CSAF TC
+  SPDX-License-Identifier: LicenseRef-OASIS-CSAF-TC-License
+-->

--- a/data/navlinksExternal.json
+++ b/data/navlinksExternal.json
@@ -11,7 +11,7 @@
     },
     {
         "label": "FAQ",
-        "url": "https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/guidance/faq.md",
-        "external": true
+        "url": "/faq/",
+        "external": false
     }
 ]

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,1 @@
+{{- template "alias.html" (dict "Permalink" .Params.target) -}}


### PR DESCRIPTION
Closes https://github.com/oasis-open/csaf-documentation

Context: originally csaf.io had redirecting to FAQ insted instead of the direct link. It was discussed in the repository of csaf.dev that this logic should be also implemented on the csaf.io website built with Hugo.