### PR TITLE
improve /Specifications to encourage feedback

### DIFF
--- a/layouts/_default/specification.html
+++ b/layouts/_default/specification.html
@@ -47,6 +47,7 @@
       <p>
       All feedback and suggestions from non members are welcome and encouraged!
       Write us via the comment mailing list (see footer).
+      </p>
     </div>
     <!-- #endregion -->
   </div>


### PR DESCRIPTION
Dear Maintainers (@sthagen, @justmurphy, @tschmidtb51), consider adding a welcome message after merging the new footer (#149).

The back and forth about how to contribute to the standard via the mailinglist with the footer on the specification page is not ideal, but still a clear and major improvement. After seeing #149: being more explicit about feedback on the /Specification subpage would address non members better. (And on the community days, I had the feeling that overall more feedback is very welcome.)