### PR TITLE
improve link to website contribution

### DIFF
--- a/layouts/partials/general/footer.html
+++ b/layouts/partials/general/footer.html
@@ -7,7 +7,7 @@
       <div class="small">
         <a
           class="d-block"
-          href="https://github.com/oasis-open/csaf-documentation/blob/master/CONTRIBUTING.md#fork-and-pull-collaboration-model"
+          href="https://github.com/oasis-open/csaf-documentation/blob/main/README-repo.md"
         >
           To this website
         </a>


### PR DESCRIPTION
  switch link in the footer to README-repo.md and the correct branch `main`.
  README-repo.md links the more formal README.md and other hints,
  so this way potential contributors get to see all information.
  (The old target was pointing to CONTRIBUTING.md, which does not link
  the other files, but gets linked from  README-repo.md.)