### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Hugo
         env:
-          HUGO_VERSION: '0.150.0'
+          HUGO_VERSION: '0.163.0'
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb

--- a/README-repo.md
+++ b/README-repo.md
@@ -173,7 +173,7 @@ and you get the site files in `public/`.
 
 The `hugo.toml` file contains the main configuration settings for the Hugo project.
 
-- **languageCode**: Defines the default language for the website
+- **locale**: Defines the default language for the website
   (set to American English).
 
 - **title**: The title of the website.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-languageCode = 'en-US'
+locale = 'en-US'
 title = 'CSAF'
 disableKinds = ["taxonomy", "RSS", "sitemap"]
 ignoreFiles = [".license$"]

--- a/layouts/_default/presentations.html
+++ b/layouts/_default/presentations.html
@@ -2,7 +2,7 @@
 <main class="container-fluid bg-gray-400 px-3 px-lg-5">
   <div class="container py-4 py-lg-5">
     <div class="d-flex flex-column gap-4 gap-lg-5">
-      {{ range .Site.Data.presentations }}
+      {{ range hugo.Data.presentations }}
         <div class="ratio-16x9 mx-auto">
           {{ partial "general/youtube.html" .link }}
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
   <section class="py-5">
     <div class="index__container container">
       <div class="row g-4 flex-column flex-sm-row">
-        {{ range .Site.Data.index_links }}
+        {{ range hugo.Data.index_links }}
           <div class="col-12 col-md-6 col-lg-3">
             {{ partial "pages/index/index-card.html" . }}
           </div>

--- a/layouts/partials/general/highlighted-link.html
+++ b/layouts/partials/general/highlighted-link.html
@@ -1,4 +1,4 @@
-{{ $highlight := .Site.Data.navbarHighlightedLink }}
+{{ $highlight := hugo.Data.navbarHighlightedLink }}
 {{ $current := .RelPermalink }}
 
 {{ $hasVisibleContent := and ($highlight.visible) ($highlight.url) ($highlight.text) }}

--- a/layouts/partials/general/navbar-links.html
+++ b/layouts/partials/general/navbar-links.html
@@ -1,9 +1,9 @@
 <ul class="navbar-nav">
-  {{ range .Site.Data.navlinksInternal }}
+  {{ range hugo.Data.navlinksInternal }}
     {{ partial "general/navbar-link.html" (dict "link" . "page" $.Page) }}
   {{ end }}
   <li class="navbar-nav__separator"></li>
-  {{ range .Site.Data.navlinksExternal }}
+  {{ range hugo.Data.navlinksExternal }}
     {{ partial "general/navbar-link.html" (dict "link" .) }}
   {{ end }}
   <li>

--- a/layouts/partials/pages/events/sponsors.html
+++ b/layouts/partials/pages/events/sponsors.html
@@ -1,4 +1,4 @@
-{{ $groups := site.Data }}
+{{ $groups := hugo.Data }}
 {{ range (split .jsonPath ".") }}
   {{ $groups = index $groups . }}
 {{ end }}


### PR DESCRIPTION
Resolves #159 

No more warnings for: hugo v0.163.0-4a9485336a3ff2cea07ab88e2a17ec34d5baaa6e+extended linux/amd64 BuildDate=2026-06-08T14:13:03Z VendorInfo=snap:0.163.0