### PR TITLE
feat: Separate Tools and Services

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -1,0 +1,30 @@
+---
+title: 'CSAF Open Source Services'
+date: '2026-08-26T11:54:26+01:00'
+layout: 'tools'
+draft: false
+---
+<!--
+  SPDX-FileCopyrightText: 2026 OASIS CSAF TC
+  SPDX-License-Identifier: LicenseRef-OASIS-CSAF-TC-License
+-->
+
+{{% card %}}
+### [Secvisogram](https://secvisogram.github.io/)
+Secvisogram is a tool for creating and editing advisories in CSAF format.
+{{% source "https://github.com/secvisogram/secvisogram/" %}}
+{{% license Apache-2.0 %}}
+{{% /card %}}
+
+{{% card %}}
+### [CSAF Visualizer](https://json.csaf.io/)
+A tool to visualize the CSAF JSON Schema.
+{{% license Apache-2.0 %}}
+{{% /card %}}
+
+{{% card %}}
+### [CSAF Provider Online Check](https://check.provider.csaf.dev/)
+A website which provides easy access to the CSAF Provider Checker.
+{{% source "https://github.com/csaf-tools/provider-online-check/" %}}
+{{% license Apache-2.0 %}}
+{{% /card %}}

--- a/content/services.md
+++ b/content/services.md
@@ -13,7 +13,7 @@ draft: false
 ### [Secvisogram](https://secvisogram.github.io/)
 Secvisogram is a tool for creating and editing advisories in CSAF format.
 {{% source "https://github.com/secvisogram/secvisogram/" %}}
-{{% license Apache-2.0 %}}
+{{% license MIT %}}
 {{% /card %}}
 
 {{% card %}}
@@ -26,5 +26,19 @@ A tool to visualize the CSAF JSON Schema.
 ### [CSAF Provider Online Check](https://check.provider.csaf.dev/)
 A website which provides easy access to the CSAF Provider Checker.
 {{% source "https://github.com/csaf-tools/provider-online-check/" %}}
+{{% license Apache-2.0 %}}
+{{% /card %}}
+
+{{% card %}}
+### [CSAF Provider Index](https://csaf-provider-index.intevation.de)
+A website listing known CSAF Providers and Publishers. Users can submit new entries to the index.
+{{% source "https://heptapod.host/intevation/csaf-provider-index" %}}
+{{% license Apache-2.0 %}}
+{{% /card %}}
+
+{{% card %}}
+### [Sec-O-Simple](https://sec-o-simple.github.io/)
+A website guiding you through the creation of CSAF documents. Allows editing of existing documents as well.
+{{% source "https://github.com/sec-o-simple/sec-o-simple" %}}
 {{% license Apache-2.0 %}}
 {{% /card %}}

--- a/content/tools.md
+++ b/content/tools.md
@@ -10,106 +10,115 @@ draft: false
 -->
 
 {{% card %}}
-### [Secvisogram](https://secvisogram.github.io/)
-Secvisogram is a tool for creating and editing advisories in CSAF format.
-{{% /card %}}
-
-{{% card %}}
-### [CSAF Visualizer](https://json.csaf.io/)
-A tool to visualize the CSAF JSON Schema.
-{{% /card %}}
-
-{{% card %}}
 ### [CSAF Provider](https://github.com/gocsaf/csaf/blob/main/docs/csaf_provider.md)
 An implementation of the role CSAF Trusted Provider, also offering a simple HTTPS based management service.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Uploader](https://github.com/gocsaf/csaf/blob/main/docs/csaf_uploader.md)
 A command line tool that uploads CSAF documents to the CSAF Provider.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Aggregator](https://github.com/gocsaf/csaf/blob/main/docs/csaf_aggregator.md)
 An implementation of the role CSAF Aggregator.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Checker](https://github.com/gocsaf/csaf/blob/main/docs/csaf_checker.md)
 A tool for testing a CSAF Trusted Provider according to [Section 7 of the CSAF standard](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#7-distributing-csaf-documents).
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Downloader](https://github.com/gocsaf/csaf/blob/main/docs/csaf_downloader.md)
-A tool to download CSAF content from a specific domain / CSAF provider.<br>
+A tool to download CSAF content from a specific domain / CSAF provider.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Validator Library](https://github.com/secvisogram/csaf-validator-lib)
 A JavaScript library is intended to include logic that can be shared across application working with CSAF.
+{{% license MIT %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Validator Service](https://github.com/secvisogram/csaf-validator-service)
 A service to validate documents against the CSAF standard. It uses the csaf-validator-lib "under-the-hood".
+{{% license MIT %}}
 {{% /card %}}
 
 {{% card %}}
 ### [BSI Secvisogram CSAF Backend CMS](https://github.com/secvisogram/csaf-cms-backend)
 The CSAF Content Management System (CMS) Secvisogram backend code and documentation
+{{% license MIT %}}
 {{% /card %}}
 
 {{% card %}}
 ### [paikalta](https://pypi.org/project/paikalta/)
 A tool for testing a CSAF Trusted Provider according to [Pypi](https://pypi.org/project/paikalta/).
+{{% license MIT %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Walker](https://github.com/ctron/csaf-walker)
 A Rust library and command line tool for consuming and analyzing CSAF documents.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [Clouditor](https://github.com/clouditor/clouditor?tab=readme-ov-file#using-the-extra-discoverers-eg-csaf)
 Clouditor is a tool for the continuous assurance of cloud and other backend services. It supports the conformance check of CSAF (trusted) providers as part of vulnerability management controls.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [SecObserve](https://github.com/SecObserve/SecObserve)
 An open source vulnerability management system that can produce and consume CSAF VEX documents.
+{{% license 3-clause BSD %}}
 {{% /card %}}
 
 {{% card %}}
 ### [Trivy](https://aquasecurity.github.io/trivy/)
 A comprehensive and versatile security scanner that look for security issues.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
-### [Trustification](https://github.com/trustification/trustification)
+### [Trustify](https://github.com/guacsec/trustify)
 A collection of software that allow you to store bill of materials (SBOM), vulnerability information (VEX) for your organization and use that information to learn impact of vulnerabilities and dependency changes.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [CSAF Perl Tookit](https://metacpan.org/dist/CSAF)
 A Perl distribution (with modules and command-line tools) for create, validate, convert (in HTML), publish and download CSAF documents.
+{{% license Artistic-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [kotlin-csaf](https://github.com/csaf-sbom/kotlin-csaf)
 A Kotlin implementation of the CSAF standard for the JVM. It supports parsing and validation of CSAF 2.0 documents.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [csaf-rust](https://github.com/csaf-poc/csaf-rust)
 A Rust implementation of the CSAF standard. It supports parsing (and partial validation) of CSAF 2.0 and CSAF 2.1 (Draft) documents.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
 ### [DependencyTrack CSAF Integration](https://github.com/csaf-sbom/hyades-csaf)
 An integration for the popular dependency management system DependencyTrack.
+{{% license Apache-2.0 %}}
 {{% /card %}}
 
 {{% card %}}
-### [CSAF Provider Online Check](https://check.provider.csaf.dev/)
-A website which provides easy access to the CSAF Provider Checker.
+### [ISDuBA](https://github.com/ISDuBA/ISDuBA/blob/main/README.md)
+A web application for downloading and evaluating security advisories.
+{{% license Apache-2.0 %}}
 {{% /card %}}

--- a/data/navlinksInternal.json
+++ b/data/navlinksInternal.json
@@ -18,5 +18,10 @@
         "url": "/tools/",
         "label": "Tools",
         "external": false
+    },
+    {
+        "url": "/services/",
+        "label": "Services",
+        "external": false
     }
 ]

--- a/layouts/_default/tools.html
+++ b/layouts/_default/tools.html
@@ -3,7 +3,7 @@
   <!-- #region: Title -->
   <section class="blue-gradient">
     <div class="container">
-      <h1 class="py-10 lh-1 fw-normal">{{ .Title }}</h1>
+      <h1 class="py-4 pb-5 lh-1 fw-normal">{{ .Title }}</h1>
     </div>
   </section>
   <!-- #endregion -->

--- a/layouts/shortcodes/license.html
+++ b/layouts/shortcodes/license.html
@@ -1,0 +1,1 @@
+<div class="pt-4">License: {{ .Get 0 | markdownify }}</div>

--- a/layouts/shortcodes/source.html
+++ b/layouts/shortcodes/source.html
@@ -1,0 +1,1 @@
+<div>Source: <a href="{{ .Get 0 }}" target="_blank" rel="nofollow">{{ .Get 0 }}</a></div>


### PR DESCRIPTION
feat: Add License and Source References

As per #170

Reduce height of Blue Background Title Bar. 

Also add ISDuBA to Tools list and changes the link and name from archived [version](https://github.com/trustification/trustification) to the maintained one indicated in the repo.

The source link for json.csaf.io could not be determined, so if anyone knows the source for that I will gladly add that.

Not sure if it is desired to create an entire new page for the currently 3 services (as per my own definition / intuition), or whether it would be better to somehow split it up on the already existing tools page and rename it instead.
Also not sure if the reduction of the blue bar height is desired, it seemed excessive and steal all the real estate from the content, so I reduced it  to about a third.

<img width="1217" height="667" alt="image" src="https://github.com/user-attachments/assets/665ae1d7-3bfa-4ea7-9371-2325cfdb159b" />
